### PR TITLE
Move printermanager to user mode

### DIFF
--- a/Modules/PrinterManager/PrintManagerBridge.cs
+++ b/Modules/PrinterManager/PrintManagerBridge.cs
@@ -62,6 +62,5 @@ namespace FOG.Modules.PrinterManager
         public abstract void Remove(string name, bool verbose = false);
         public abstract void Default(string name, bool verbose = false);
         public abstract void Configure(Printer printer, bool verbose = false);
-        public abstract void ApplyChanges();
     }
 }

--- a/Modules/PrinterManager/PrinterManager.cs
+++ b/Modules/PrinterManager/PrinterManager.cs
@@ -96,9 +96,6 @@ namespace FOG.Modules.PrinterManager
                 }
             }
             printerAdded = BatchConfigure(msg.Printers) || printerAdded;
-
-            if(printerAdded)
-                _instance.ApplyChanges();
         }
 
         private void RemoveExtraPrinters(List<Printer> newPrinters, DataContracts.PrinterManager msg, List<string> installedPrinters )

--- a/Modules/PrinterManager/Unix/UnixPrinterManager.cs
+++ b/Modules/PrinterManager/Unix/UnixPrinterManager.cs
@@ -73,9 +73,5 @@ namespace FOG.Modules.PrinterManager
             throw new NotImplementedException();
         }
 
-        public override void ApplyChanges()
-        {
-            
-        }
     }
 }

--- a/Modules/PrinterManager/Windows/WindowsPrinterManager.cs
+++ b/Modules/PrinterManager/Windows/WindowsPrinterManager.cs
@@ -135,29 +135,6 @@ namespace FOG.Modules.PrinterManager
             PrintUI($"/Sr /n \"{printer.Name}\" /a \"{printer.ConfigFile}\" m f g p", verbose);
         }
 
-        public override void ApplyChanges()
-        {
-            Log.Entry(LogName, "Restarting spooler");
-            try
-            {
-                const int timeoutMilliseconds = 60 * 1000;
-                var spooler = new ServiceController("spooler");
-
-                var timeout = TimeSpan.FromMilliseconds(timeoutMilliseconds);
-                spooler.Stop();
-                spooler.WaitForStatus(ServiceControllerStatus.Stopped, timeout);
-
-                timeout = TimeSpan.FromMilliseconds(timeoutMilliseconds);
-                spooler.Start();
-                spooler.WaitForStatus(ServiceControllerStatus.Running, timeout);
-            }
-            catch (Exception ex)
-            {
-                Log.Error(LogName, "Failed to restart the print spooler");
-                Log.Error(LogName, ex);
-            }
-        }
-
         private void AddIPPort(Printer printer, string remotePort)
         {
             var conn = new ConnectionOptions

--- a/Service/FOGSystemService.cs
+++ b/Service/FOGSystemService.cs
@@ -102,8 +102,8 @@ namespace FOG
                     var alo = response.GetSubResponse("autologout");
                     Settings.Set("ALOTime", (alo == null) ? "0" : alo.GetField("time"));
 
-                    var pDefault = response.GetSubResponse("printermanager");
-                    Settings.Set("DefaultPrinter", (pDefault == null) ? "" : pDefault.GetField("default"));
+                    var pPrinter = response.GetSubResponse("printermanager");
+                    Settings.Set("printermanager", pPrinter.Data);
 
                     var display = response.GetSubResponse("displaymanager");
                     Settings.Set("DisplayX", (display == null || display.Error) ? "" : display.GetField("x"));
@@ -190,7 +190,6 @@ namespace FOG
                 new TaskReboot(),
                 new HostnameChanger(),
                 new SnapinClient(),
-                new PrinterManager(),
                 new PowerManagement(),
                 new UserTracker()
             };

--- a/UserService/FOGUserService.cs
+++ b/UserService/FOGUserService.cs
@@ -73,6 +73,7 @@ namespace FOG
             _modules =  new IModule[]
             {
                 new AutoLogOut(),
+                new PrinterManager(),
                 new DefaultPrinterManager(),
                 new DisplayManager()
             };
@@ -93,15 +94,17 @@ namespace FOG
                 string printer;
 
                 int.TryParse(Settings.Get("ALOTime"), out alo);
-                printer = Settings.Get("DefaultPrinter");
                 int.TryParse(Settings.Get("DisplayX"), out displayX);
                 int.TryParse(Settings.Get("DisplayY"), out displayY);
                 int.TryParse(Settings.Get("DisplayR"), out displayR);
 
+                printer = Settings.GetSubResponse("printermanager");
+
                 var data = new JObject
                 {
                     ["autologout"] = new JObject { ["time"] = alo },
-                    ["defaultprintermanager"] = new JObject { ["name"] = printer },
+                    ["defaultprintermanager"] = new JObject { ["name"] = printer.GetField("default") },
+                    ["printermanager"] = printer.Data,
                     ["displaymanager"] = new JObject { ["error"] = ((displayX == -1) ? "Configuration not set" : "ok"),
                         ["x"] = displayX,
                         ["y"] = displayY,

--- a/UserService/FOGUserService.cs
+++ b/UserService/FOGUserService.cs
@@ -91,7 +91,7 @@ namespace FOG
                 int displayX;
                 int displayY;
                 int displayR;
-                string printer;
+                Response printer;
 
                 int.TryParse(Settings.Get("ALOTime"), out alo);
                 int.TryParse(Settings.Get("DisplayX"), out displayX);


### PR DESCRIPTION
Move printer manger to user mode via foguserservice. Each poll cycle, add the printer configuration to the session cache so that all foguserservice's will have up-to-date information.  Bug #90 . 

*NOTE* This is fix still requires validation before merging.

This is not a proper fix, as a printer may still be "leftover" if removed while the user service is not running. But it should at least prevent added printers from not showing to users. A larger refactoring will be needed to fix the problems in this module.