### PR TITLE
Fix for Issue #139

### DIFF
--- a/Modules/PrinterManager/Windows/WindowsPrinterManager.cs
+++ b/Modules/PrinterManager/Windows/WindowsPrinterManager.cs
@@ -154,9 +154,14 @@ namespace FOG.Modules.PrinterManager
                     else
                         throw new FileNotFoundException("Config file not found after trying to parse");
                 }
-                catch
+                catch (FileNotFoundException)
                 {
                     Log.Error(LogName, $"Failed to configure {printer.Name}! Couldn't find {printer.ConfigFile}");
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(LogName, $"Failed to configure {printer.Name}!");
+                    Log.Error(LogName, ex);
                 }
             }
         }


### PR DESCRIPTION
Added additional printUI call with the /g flag.
Added check to see if printer.ConfigFile is a file and is accessible.
Added parsing of printer.ConfigFile path if file is not accessible to check for variables.
Added log message if printer.ConfigFile cannot be found.
